### PR TITLE
add: environment variable for voice id

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,7 @@ const upload = multer({ storage: multer.memoryStorage() });
 
 dotenv.config();
 const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
-const ELEVENLABS_VOICE_ID = 'iP95p4xoKVk53GoZ742B';
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID;
 const ELEVENLABS_MODEL_ID = 'eleven_multilingual_v2';
 
 // Cloudflare R2 config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to allow the ElevenLabs voice ID to be set through environment variables for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->